### PR TITLE
Improve auto-loader performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ let elements = [
 	"nd-calendar",
 ];
 
-await Promise.all(elements.map(id => import(`./${id}/${id}.js`)));
+for (let id of elements) {
+	import(`./${id}/${id}.js`);
+}
 
 // CSS only modules
 let modules = [


### PR DESCRIPTION
as far as I can tell, there's no reason to have JavaScript modules block CSS modules, so we don't need to `await` imports