### PR TITLE
Fix spinner value precision

### DIFF
--- a/elements/nd-slider/nd-slider.js
+++ b/elements/nd-slider/nd-slider.js
@@ -91,7 +91,8 @@ let self = class NudeSlider extends HTMLElement {
 			let value = this[source + "Element"].value;
 
 			if (source === "slider") {
-				this.valueElement.value = this.show === "progress" ? +(this.progressAt(value) * 100).toPrecision(4) : value;
+				value = this.show === "progress" ? this.progressAt(value) * 100 : value;
+				this.valueElement.value = +value.toPrecision(4);
 			}
 			else if (source === "value") {
 				this.sliderElement.value = this.show === "progress" ? this.valueAt(value / 100) : value;


### PR DESCRIPTION
We should avoid IEEE754 values not only when showing the progress but also the value.

Addresses the same issue as https://github.com/color-js/elements/pull/30.