### PR TITLE
fixed aria-pressed getting stuck when picker closed via ESC key

### DIFF
--- a/elements/drop-down/drop-down.js
+++ b/elements/drop-down/drop-down.js
@@ -1,3 +1,5 @@
+import { observeElement } from "https://unpkg.com/select-events/src/coreFunctionality.js";
+
 if (!HTMLSlotElement.prototype.assign) {
 	// Include Imperative Slot Assignment polyfill
 	await import("https://unpkg.com/dom-slot-assign");
@@ -11,6 +13,7 @@ export default class DropDown extends HTMLElement {
 	#resizeObserver
 	#menu
 	#trigger
+	#reset
 
 	constructor () {
 		super();
@@ -101,6 +104,7 @@ export default class DropDown extends HTMLElement {
 	}
 
 	#childrenChanged () {
+		this.#reset?.();
 		let select = this.querySelectorAll(":scope > select")[0];
 		let trigger = this.querySelectorAll(":scope > :not(select)")[0];
 		this.#triggerSlot.assign(trigger);
@@ -108,6 +112,16 @@ export default class DropDown extends HTMLElement {
 
 		this.#trigger = trigger;
 		this.#menu = select;
+
+		if (select) {
+			const { disconnect } = observeElement(select, (select, selectOpened) => {
+				if (selectOpened)
+					this.#trigger.setAttribute("aria-pressed", "true");
+				else
+					this.#trigger.removeAttribute("aria-pressed");
+			});
+			this.#reset = () => disconnect();
+		}
 
 		let label = this.#menu.ariaLabel || "Select:";
 		this.#menu.insertAdjacentHTML("afterbegin", `<option style="opacity: .5" disabled selected>${label}</option>`);


### PR DESCRIPTION
The `<drop-down>` custom element of `nudeui` is currently marked as a failed experiment.
The reason given:
> It is impossible to reliably detect when the `<select>` is closed, so when the menu is closed with no selection, `aria-pressed` lingers until the button is unfocused.

I recently found a way to reliably detect opening/closing `<select>` picker dropdowns: the CSS selector `select:open` will match when the picker dropdown is open, and can be combined with a _StyleObserver_ to trigger a callback into the script code.
I published the functionality as [select-events](https://github.com/teetotum/select-events).

This PR aims to fix this particular issue and keep the changes small and focused.
It might be prudent to also clean up some lines of code that deal with `aria-pressed` and are now superfluous.

I noticed there are some parts in `drop-down.js` that could well need some love; let me know if another PR is welcome.
Among those parts are:
- the _trigger_ is not actually triggering anything (there is no click listener),
- visually the dropdown has a huge gap towards the trigger,
- the _label option_ is potentially inserted more than once
- the `<select>` itself seems to be unnecessary, can not the `<drop-down>` itself receive `<option>` elements?